### PR TITLE
アイコン画像を使いやすくする

### DIFF
--- a/app/components/CharacterImage.tsx
+++ b/app/components/CharacterImage.tsx
@@ -1,0 +1,15 @@
+export function CharacterImage(props: {
+  name: string;
+  color?: string;
+  class?: string;
+}) {
+  const color = props.color ?? "lp";
+  const basePath = "/static/characters/icons/";
+  return (
+    <img
+      src={`${basePath}${props.name}_${color}.gif`}
+      alt={props.name}
+      class={props.class ?? ""}
+    />
+  );
+}

--- a/app/components/ColorTable.tsx
+++ b/app/components/ColorTable.tsx
@@ -1,3 +1,5 @@
+import { CharacterImage } from "./CharacterImage";
+
 const colors = ["lp", "mp", "hp", "lk", "mk", "hk", "pp", "kk"];
 const colorLabel = new Map([
   ["lp", "小P"],
@@ -26,9 +28,7 @@ export function ColorTable(props: { name: string }) {
         <tr>
           {colors.map((color) => (
             <td key={color} class="p-1.5">
-              <img
-                src={`/static/characters/icons/${props.name}_${color}.gif`}
-              />
+              <CharacterImage name={props.name} color={color} />
             </td>
           ))}
         </tr>

--- a/app/remark/CharacterImage.ts
+++ b/app/remark/CharacterImage.ts
@@ -1,0 +1,57 @@
+import type { Image, Text } from "mdast";
+import type { Node, Parent } from "unist";
+import { visit } from "unist-util-visit";
+
+export default function remarkCharacterImage() {
+  return (tree: Node) => {
+    visit(
+      tree,
+      "text",
+      (node: Text, index: number | null, parent: Parent | null) => {
+        if (!parent || index === null) return;
+
+        const regex = /\[([^\]]+)\]/g; // Matches [name] format
+        const matches = Array.from(node.value.matchAll(regex));
+
+        if (matches.length > 0) {
+          const newNodes: (Text | Image)[] = [];
+          let lastIndex = 0;
+
+          matches.forEach((match) => {
+            const name = match[1]; // Extract the character name
+            const imageUrl = `/static/characters/icons/${name}_lp.gif`; // Always use the "lp" color
+
+            // Add the text before the match
+            if (match.index! > lastIndex) {
+              newNodes.push({
+                type: "text",
+                value: node.value.slice(lastIndex, match.index),
+              });
+            }
+
+            // Add the image node
+            newNodes.push({
+              type: "image",
+              url: imageUrl,
+              title: null,
+              alt: name, // Set the character name as alt text
+            });
+
+            lastIndex = match.index! + match[0].length;
+          });
+
+          // Add the remaining text after the last match
+          if (lastIndex < node.value.length) {
+            newNodes.push({
+              type: "text",
+              value: node.value.slice(lastIndex),
+            });
+          }
+
+          // Replace the original node with the new nodes
+          parent.children.splice(index, 1, ...newNodes);
+        }
+      },
+    );
+  };
+}

--- a/app/routes/ja/characters/_renderer.tsx
+++ b/app/routes/ja/characters/_renderer.tsx
@@ -1,5 +1,6 @@
 import { jsxRenderer, useRequestContext } from "hono/jsx-renderer";
 import { BackButton } from "../../../components/BackButton";
+import { CharacterImage } from "../../../components/CharacterImage";
 import { ColorTable } from "../../../components/ColorTable";
 import { characters } from "../../../domains/character";
 
@@ -18,7 +19,7 @@ export default jsxRenderer(({ children, Layout, frontmatter }) => {
     <Layout title={`キャラクター紹介 ${character.name}`}>
       <hgroup>
         <h1 class="mt-4 flex items-center gap-2 text-3xl">
-          <img src={`/static/characters/icons/${character.id}_lp.gif`} />
+          <CharacterImage name={character.id} />
           {character.name}
         </h1>
         {frontmatter.tagline && (

--- a/app/routes/ja/commands/_renderer.tsx
+++ b/app/routes/ja/commands/_renderer.tsx
@@ -1,5 +1,6 @@
 import { jsxRenderer, useRequestContext } from "hono/jsx-renderer";
 import { BackButton } from "../../../components/BackButton";
+import { CharacterImage } from "../../../components/CharacterImage";
 import { characters } from "../../../domains/character";
 
 export default jsxRenderer(({ children, Layout, frontmatter }) => {
@@ -16,7 +17,7 @@ export default jsxRenderer(({ children, Layout, frontmatter }) => {
   return (
     <Layout title={`コマンド一覧 ${character.name}`}>
       <h1 class="mt-4 flex items-center gap-2 text-3xl">
-        <img src={`/static/characters/icons/${character.id}_lp.gif`} />
+        <CharacterImage name={character.id} />
         {character.name}
       </h1>
       <article class="mt-2">

--- a/app/routes/ja/commands/anakaris.mdx
+++ b/app/routes/ja/commands/anakaris.mdx
@@ -30,15 +30,15 @@
 
 | 吸える技 | 相手キャラ |
 |---|---|
-| 王家の裁き | ![](/static/characters/icons/anakaris_lp.gif) アナカリス |
-| ソニックウェーブ | ![](/static/characters/icons/aulbath_lp.gif) オルバス |
-| 各種ミサイル | ![](/static/characters/icons/bulleta_lp.gif) バレッタ |
-| 大Kの地雷 | ![](/static/characters/icons/bulleta_lp.gif) バレッタ |
-| カオスフレア | ![](/static/characters/icons/demitri_lp.gif) デミトリ |
-| ディオ=セーガ | ![](/static/characters/icons/jedah_lp.gif) ジェダ |
-| 暗器砲 | ![](/static/characters/icons/leilei_lp.gif) レイレイ |
-| ソウルフラッシュ | ![](/static/characters/icons/lilith_lp.gif) リリス |
-| ソウルフィスト | ![](/static/characters/icons/morrigan_lp.gif) モリガン |
+| 王家の裁き | [anakaris] アナカリス |
+| ソニックウェーブ | [aulbath] オルバス |
+| 各種ミサイル | [bulleta] バレッタ |
+| 大Kの地雷 | [bulleta] バレッタ |
+| カオスフレア | [demitri] デミトリ |
+| ディオ=セーガ | [jedah] ジェダ |
+| 暗器砲 | [leilei] レイレイ |
+| ソウルフラッシュ | [lilith] リリス |
+| ソウルフィスト | [morrigan] モリガン |
 
 絡め魂やポイズンブレスは吸えないので注意。また、各種EX技（中華弾など）も吸えない。
 

--- a/app/routes/ja/commands/felicia.mdx
+++ b/app/routes/ja/commands/felicia.mdx
@@ -74,10 +74,10 @@ ESにするとダメージは高くなるが、自動二択として機能しな
 
 | 可否 | 対象キャラ |
 |---|---|
-| 確定 | ![アナカリス](/static/characters/icons/anakaris_lp.gif) ![ビシャモン](/static/characters/icons/bishamon_lp.gif) ![サスカッチ](/static/characters/icons/sasquatch_lp.gif) ![ビクトル](/static/characters/icons/victor_lp.gif) |
-| 難しい | ![デミトリ](/static/characters/icons/demitri_lp.gif) ![ガロン](/static/characters/icons/gallon_lp.gif) ![リリス](/static/characters/icons/lilith_lp.gif) ![モリガン](/static/characters/icons/morrigan_lp.gif) |
-| 空振り | ![バレッタ](/static/characters/icons/bulleta_lp.gif) ![ジェダ](/static/characters/icons/jedah_lp.gif) ![Q-Bee](/static/characters/icons/q-bee_lp.gif) ![レイレイ](/static/characters/icons/leilei_lp.gif) ![ザベル](/static/characters/icons/zabel_lp.gif) |
-| 特殊 | ![オルバス](/static/characters/icons/aulbath_lp.gif) |
+| 確定 | [anakaris] [bishamon] [sasquatch] [victor] |
+| 難しい | [demitri] [gallon] [lilith] [morrigan] |
+| 空振り | [bulleta] [jedah] [q-bee] [leilei] [zabel] |
+| 特殊 | [aulbath] |
 
 「確定」は相手の起き上がり方向に関わらず確定。
 

--- a/app/routes/ja/index.tsx
+++ b/app/routes/ja/index.tsx
@@ -1,3 +1,4 @@
+import { CharacterImage } from "../../components/CharacterImage";
 import { characters } from "../../domains/character";
 import type { Meta } from "../../types";
 
@@ -67,10 +68,7 @@ export default function Top() {
                 href={`./characters/${v.id}`}
                 class="flex items-center gap-2 text-indigo-300 underline"
               >
-                <img
-                  src={`/static/characters/icons/${v.id}_lp.gif`}
-                  class="h-8 w-8"
-                />
+                <CharacterImage name={v.id} />
                 {v.name}
               </a>
             </li>

--- a/app/routes/ja/statistics/hitBox.tsx
+++ b/app/routes/ja/statistics/hitBox.tsx
@@ -1,3 +1,4 @@
+import { CharacterImage } from "../../../components/CharacterImage";
 import { characters } from "../../../domains/character";
 import { sortByKey } from "../../../domains/utils";
 
@@ -89,10 +90,7 @@ function HeightTable(props: {
         {props.rows.map((row) => (
           <tr key={row.id}>
             <td class="flex items-center gap-2 whitespace-nowrap border border-zinc-500 px-2 py-1 text-left">
-              <img
-                src={`/static/characters/icons/${row.id}_lp.gif`}
-                class="m-0 h-8 w-8"
-              />
+              <CharacterImage name={row.id} class="m-0 h-8 w-8" />
               {row.name}
             </td>
             <td class="whitespace-nowrap border border-zinc-500 px-2 py-1 text-right">

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,15 @@
         "honox": "^0.1.26",
         "remark-frontmatter": "5.0.0",
         "remark-gfm": "4.0.0",
-        "remark-mdx-frontmatter": "5.0.0"
+        "remark-mdx-frontmatter": "5.0.0",
+        "unist-util-visit": "5.0.0"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20240529.0",
         "@hono/vite-build": "^1.0.0",
         "@hono/vite-dev-server": "^0.16.0",
+        "@types/hast": "3.0.4",
+        "@types/mdast": "4.0.4",
         "autoprefixer": "10.4.20",
         "postcss": "8.4.49",
         "prettier": "3.4.2",
@@ -1222,6 +1225,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
       "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
       }
@@ -1230,6 +1234,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
       }
@@ -5566,6 +5571,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
       "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-is": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -14,12 +14,15 @@
     "honox": "^0.1.26",
     "remark-frontmatter": "5.0.0",
     "remark-gfm": "4.0.0",
-    "remark-mdx-frontmatter": "5.0.0"
+    "remark-mdx-frontmatter": "5.0.0",
+    "unist-util-visit": "5.0.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240529.0",
     "@hono/vite-build": "^1.0.0",
     "@hono/vite-dev-server": "^0.16.0",
+    "@types/hast": "3.0.4",
+    "@types/mdast": "4.0.4",
     "autoprefixer": "10.4.20",
     "postcss": "8.4.49",
     "prettier": "3.4.2",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import remarkFrontmatter from "remark-frontmatter";
 import remarkGfm from "remark-gfm";
 import remarkMdxFrontmatter from "remark-mdx-frontmatter";
 import { defineConfig } from "vite";
+import remarkCharacterImage from "./app/remark/CharacterImage";
 
 export default defineConfig(({ mode }) => {
   console.log(mode);
@@ -26,7 +27,12 @@ export default defineConfig(({ mode }) => {
         honox({ devServer: { adapter } }),
         mdx({
           jsxImportSource: "hono/jsx",
-          remarkPlugins: [remarkFrontmatter, remarkMdxFrontmatter, remarkGfm],
+          remarkPlugins: [
+            remarkFrontmatter,
+            remarkMdxFrontmatter,
+            remarkGfm,
+            remarkCharacterImage,
+          ],
         }),
         build(),
       ],


### PR DESCRIPTION
img要素を手で書くのが面倒なので、簡単に呼び出せるようにする。

JSXを書く時は`<CharacterImage>`を、MDX内では`[characterName]`で直接書く。

MDXでcustom componentとして`<CharacterImage>`を使えるようにして実装はひとまとめにしたかったが、HonoXでうまく扱う方法が分からないので別々で実装した。結果的には記述が簡単になるのでよかったかもしれない。

remark pluginのコードそのものはChatGPTに書かせて注文を付けたりデバッグだけ手伝った。真っ当に動くまではだいぶ補助が必要だった。まだまだ仕事はなくならない。

MDX内では色を変えられないが、今のところ必要ないのでよし。