### PR TITLE
パッケージの更新チェック用スクリプトを追加する

### DIFF
--- a/changelogs.json
+++ b/changelogs.json
@@ -1,0 +1,28 @@
+{
+  "changelogs": {
+    "@hono/vite-build": [
+      "https://github.com/honojs/vite-plugins/blob/main/packages/build/CHANGELOG.md"
+    ],
+    "@hono/vite-dev-server": [
+      "https://github.com/honojs/vite-plugins/blob/main/packages/dev-server/CHANGELOG.md"
+    ],
+    "autoprefixer": ["https://github.com/postcss/autoprefixer/releases"],
+    "hono": ["https://github.com/honojs/hono/releases"],
+    "honox": ["https://github.com/honojs/honox/releases"],
+    "ora": ["https://github.com/sindresorhus/ora/releases"],
+    "postcss": ["https://github.com/postcss/postcss/releases"],
+    "prettier": [
+      "https://github.com/prettier/prettier/blob/master/CHANGELOG.md"
+    ],
+    "prettier-plugin-tailwindcss": [
+      "https://github.com/tailwindlabs/prettier-plugin-tailwindcss/releases"
+    ],
+    "remark-gfm": ["https://github.com/remarkjs/remark-gfm/releases"],
+    "remark-mdx-frontmatter": [
+      "https://github.com/remcohaszing/remark-mdx-frontmatter/releases"
+    ],
+    "tailwindcss": ["https://github.com/tailwindlabs/tailwindcss"],
+    "vite": ["https://github.com/vitejs/vite/releases"],
+    "wrangler": ["https://github.com/cloudflare/workers-sdk/releases"]
+  }
+}

--- a/garden.ts
+++ b/garden.ts
@@ -1,0 +1,138 @@
+import { spawn } from "child_process";
+import { Command } from "commander";
+import { readFileSync } from "fs";
+import ora from "ora";
+
+type PackageInfo = {
+  name: string;
+  current: string;
+  latest: string;
+};
+
+type Changelogs = Record<string, string[]>;
+
+function spawnAsync(
+  cmd: string,
+  args: string[],
+  options = {},
+): Promise<{ stdout: string; stderr: string; code: number | null }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, options);
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (data) => {
+      stdout += data;
+    });
+
+    child.stderr.on("data", (data) => {
+      stderr += data;
+    });
+
+    child.on("error", (err) => {
+      reject(err);
+    });
+
+    child.on("close", (code) => {
+      resolve({ stdout, stderr, code });
+    });
+  });
+}
+
+const retrieveOutdated = async () => {
+  const res = await spawnAsync("npm", ["outdated", "--json"]);
+  const items = Object.entries(JSON.parse(res.stdout)).map(([name, v]) => ({
+    name,
+    current: (v as any).current,
+    latest: (v as any).latest,
+  }));
+  return items;
+};
+
+const generateTable = (packages: PackageInfo[]): string[] => {
+  const res: string[] = [];
+  if (packages.length === 0) {
+    return [];
+  }
+  const items: PackageInfo[] = [
+    { name: "name", current: "current", latest: "latest" },
+    ...packages,
+  ];
+  const maxLength: Record<keyof PackageInfo, number> = {
+    name: Math.max(...items.map((v) => v.name.length)),
+    current: Math.max(...items.map((v) => v.current.length)),
+    latest: Math.max(...items.map((v) => v.latest.length)),
+  };
+  res.push("```");
+  items.map((item) => {
+    res.push(
+      [
+        item.name.padEnd(maxLength.name),
+        item.current.padStart(maxLength.current),
+        item.latest.padStart(maxLength.latest),
+      ].join("   "),
+    );
+  });
+  res.push("```");
+  res.push("");
+  return res;
+};
+
+const generateUpdateList = (
+  items: PackageInfo[],
+  changelogs: Changelogs,
+): string[] => {
+  const res: string[] = [];
+  for (const item of items) {
+    if (item.name.startsWith("@types/")) {
+      continue;
+    }
+    res.push(`## ${item.name}`);
+    res.push("");
+    const urls = changelogs[item.name];
+    if (urls) {
+      urls.map((v) => res.push(`- ${v}`));
+    } else {
+      res.push("unknown");
+    }
+    res.push("");
+  }
+  return res;
+};
+
+const createIssue = (description: string) =>
+  spawnAsync("gh", [
+    "issue",
+    "create",
+    "--web",
+    "--title",
+    "Upgrade outdated packages",
+    "--label",
+    "dependencies",
+    "--body",
+    description,
+  ]);
+
+const program = new Command();
+program.option("--dry-run", "run on dry-run mode").showHelpAfterError();
+program.parse();
+const options = program.opts();
+
+const retrieve = ora("Retrieving outdated packages...").start();
+const items = await retrieveOutdated();
+retrieve.succeed();
+
+const changelogs: { changelogs: Changelogs } = JSON.parse(
+  readFileSync("changelogs.json", "utf-8"),
+);
+
+const issuing = ora("Creating issue...").start();
+if (options.dryRun) {
+  issuing.warn();
+  console.log(generateTable(items).join("\n"));
+} else {
+  createIssue(generateTable(items).join("\n"));
+  issuing.succeed();
+}
+
+console.log(generateUpdateList(items, changelogs.changelogs).join("\n"));

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "commander": "13.1.0",
         "hono": "^4.6.10",
         "honox": "^0.1.26",
+        "ora": "8.2.0",
         "remark-frontmatter": "5.0.0",
         "remark-gfm": "4.0.0",
         "remark-mdx-frontmatter": "5.0.0",
@@ -1419,7 +1420,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1675,6 +1675,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -1724,6 +1736,33 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/collapse-white-space": {
@@ -2451,6 +2490,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
+      "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-source": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
@@ -2771,6 +2822,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2785,6 +2848,18 @@
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2885,6 +2960,34 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -3987,6 +4090,18 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/miniflare": {
       "version": "3.20241106.0",
       "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20241106.0.tgz",
@@ -4175,6 +4290,67 @@
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.4.tgz",
       "integrity": "sha512-FlDryZAahJmEF3VR3w1KogSEdWX3WhA5GPakFx4J81kEAiHyLMpdLLElS8n8dfNadMgAne/MywcvmogzscVt4g==",
       "devOptional": true
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "license": "MIT"
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
@@ -4863,6 +5039,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -5032,7 +5224,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -5090,6 +5281,18 @@
       "dependencies": {
         "as-table": "^1.0.36",
         "get-source": "^2.0.12"
+      }
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/stoppable": {
@@ -5183,7 +5386,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "basic",
       "dependencies": {
         "@mdx-js/rollup": "3.1.0",
+        "commander": "13.1.0",
         "hono": "^4.6.10",
         "honox": "^0.1.26",
         "remark-frontmatter": "5.0.0",
@@ -1762,9 +1763,10 @@
       }
     },
     "node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -4483,6 +4485,15 @@
       "bin": {
         "precinct": "bin/cli.js"
       },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/precinct/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "private": true,
   "dependencies": {
     "@mdx-js/rollup": "3.1.0",
+    "commander": "13.1.0",
     "hono": "^4.6.10",
     "honox": "^0.1.26",
     "remark-frontmatter": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "commander": "13.1.0",
     "hono": "^4.6.10",
     "honox": "^0.1.26",
+    "ora": "8.2.0",
     "remark-frontmatter": "5.0.0",
     "remark-gfm": "4.0.0",
     "remark-mdx-frontmatter": "5.0.0",


### PR DESCRIPTION
`npm outdated`の結果を見て`changelogs.json`から更新対象のライブラリを洗い出すスクリプトを追加する。

```
npx tsx garden.ts
```

で実行するとissueを立てるところまで自動でやってくれる。

更新対象のchangelogsをstdoutに出力するので、それを元に更新内容を確認していく。

`--dry-run`を付けるとissueは立てずにstdoutに情報を出すだけ。